### PR TITLE
feat: add WhatsApp recommendations and deployment hardening

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/pages.yml'
       - 'Pages/**'
       - 'shared/recommendations/**'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ Install dependencies:
 ```bash
 cd WhatsappBot
 npm install
+cp .env.example .env
 ```
 
-Create `WhatsappBot/.env` with at least:
+Edit `WhatsappBot/.env` and set at least:
 
 ```dotenv
 MANGA_API_URL=http://localhost:3000/api
 WHATSAPP_ALLOWED_NUMBERS=5491112345678,5491123456789
-CHROME_BIN=/usr/bin/google-chrome-stable
 ```
 
 Notes:
@@ -152,6 +152,7 @@ Notes:
 - numbers are normalized before comparison.
 - senders not listed in the whitelist are ignored.
 - if the whitelist is empty, the bot ignores all incoming messages.
+- `CHROME_BIN` is optional. If it is unset, the bot tries `/usr/bin/chromium-browser`, `/usr/bin/chromium`, then `/usr/bin/google-chrome-stable`.
 
 Start the bot:
 
@@ -244,7 +245,7 @@ WhatsApp bot deployment:
 bash deployment/deploy-bot.sh
 ```
 
-The bot deploy script preserves the server-side `.env` file if it already exists.
+The bot deploy script preserves the server-side `.env` file if it already exists. If it does not exist yet, the script creates it from `WhatsappBot/.env.example` so you can fill in the allowed numbers before the first run.
 
 Additional deployment details are in `deployment/SSH-DEPLOY.md`.
 

--- a/WhatsappBot/.env.example
+++ b/WhatsappBot/.env.example
@@ -1,0 +1,4 @@
+MANGA_API_URL=http://localhost:3000/api
+WHATSAPP_ALLOWED_NUMBERS=
+# Optional override. Leave unset to auto-detect Chromium or Chrome.
+# CHROME_BIN=/usr/bin/chromium-browser

--- a/WhatsappBot/index.js
+++ b/WhatsappBot/index.js
@@ -2,23 +2,36 @@ require('dotenv').config();
 
 const { Client, LocalAuth } = require('whatsapp-web.js');
 const qrcode = require('qrcode-terminal');
+const { resolveBrowserPath } = require('./src/browser');
 const { handleMessage } = require('./src/router');
 const { getAllowedNumberCount } = require('./src/authorization');
 const { createLogger } = require('./src/logger');
 
 const logger = createLogger({ fileName: 'bot.txt' });
+const browserPath = resolveBrowserPath();
+
+if (browserPath) {
+    logger.info(`Usando navegador compatible en ${browserPath}.`);
+} else {
+    logger.warn('No se detecto CHROME_BIN ni una ruta conocida de Chrome/Chromium. Puppeteer intentara resolver el navegador por defecto.');
+}
+
+const puppeteerOptions = {
+    headless: true,
+    args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+    ]
+};
+
+if (browserPath) {
+    puppeteerOptions.executablePath = browserPath;
+}
 
 const client = new Client({
     authStrategy: new LocalAuth(),
-    puppeteer: {
-        headless: true,
-        executablePath: process.env.CHROME_BIN || '/usr/bin/google-chrome-stable',
-        args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-dev-shm-usage',
-        ]
-    }
+    puppeteer: puppeteerOptions,
 });
 
 client.on('qr', (qr) => {

--- a/WhatsappBot/src/browser.js
+++ b/WhatsappBot/src/browser.js
@@ -1,0 +1,20 @@
+const fs = require('node:fs');
+
+const BROWSER_CANDIDATES = [
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+    '/usr/bin/google-chrome-stable',
+];
+
+function resolveBrowserPath(options = {}) {
+    const env = options.env || process.env;
+    const existsSync = options.existsSync || fs.existsSync;
+
+    if (env.CHROME_BIN) {
+        return env.CHROME_BIN;
+    }
+
+    return BROWSER_CANDIDATES.find((candidate) => existsSync(candidate));
+}
+
+module.exports = { resolveBrowserPath };

--- a/WhatsappBot/src/browser.test.js
+++ b/WhatsappBot/src/browser.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { resolveBrowserPath } = require('./browser');
+
+test('resolveBrowserPath prefers CHROME_BIN when it is configured', () => {
+    const browserPath = resolveBrowserPath({
+        env: { CHROME_BIN: '/custom/chrome' },
+        existsSync: () => false,
+    });
+
+    assert.equal(browserPath, '/custom/chrome');
+});
+
+test('resolveBrowserPath falls back to the first installed Chromium-compatible binary', () => {
+    const browserPath = resolveBrowserPath({
+        env: {},
+        existsSync: (candidate) => candidate === '/usr/bin/chromium-browser',
+    });
+
+    assert.equal(browserPath, '/usr/bin/chromium-browser');
+});
+
+test('resolveBrowserPath returns undefined when no configured or known binary is available', () => {
+    const browserPath = resolveBrowserPath({
+        env: {},
+        existsSync: () => false,
+    });
+
+    assert.equal(browserPath, undefined);
+});

--- a/deployment/SSH-DEPLOY.md
+++ b/deployment/SSH-DEPLOY.md
@@ -1,184 +1,108 @@
-# Deploy a Servidor via SSH
+# Deploy Over SSH
 
-Guía para compilar y desplegar MangaCount en el servidor LAN `192.168.0.50`.
+This guide documents the server-side deployment flow used by the repository scripts.
 
-## Datos del Servidor
+## Server reference
 
-| Campo         | Valor                              |
-|---------------|------------------------------------|
-| IP            | `192.168.0.50`                     |
-| SSH User      | `pihole`                           |
-| SSH Password  | `pihole`                           |
-| App directory | `/home/pihole/mangacount/app/`     |
-| Puerto        | `3000`                             |
-| URL           | http://192.168.0.50:3000           |
-| Log           | `/home/pihole/mangacount/app/manga.log` |
+| Field | Value |
+| --- | --- |
+| IP | `192.168.0.50` |
+| SSH user | `pihole` |
+| App directory | `/home/pihole/mangacount/app/` |
+| Bot directory | `/home/pihole/mangacount/bot/` |
+| Shared logs directory | `/home/pihole/mangacount/logs/` |
+| API URL | `http://192.168.0.50:3000` |
 
-## Prerrequisitos en el Servidor (ya instalados)
+## Backend deploy
 
-- .NET 8 Runtime (`/usr/bin/dotnet`)
-- PostgreSQL 16 (`MangaCount` database, user `pihole`, password `pihole`)
-- Directorio `/home/pihole/mangacount/app/` existente
-
-## ⚠️ ADVERTENCIAS IMPORTANTES
-
-### 🚫 NO instalar nginx
-MangaCount usa **Kestrel** (servidor HTTP integrado de .NET). **NUNCA instales nginx** en el servidor Pi-hole porque:
-- ❌ MangaCount NO necesita nginx (funciona independiente en puerto 3000)
-- ❌ nginx **conflicta con Pi-hole** (ambos usan puerto 80)
-- ❌ Causa error 403 Forbidden en Pi-hole web interface
-
-### ✅ Configuración correcta del servidor:
-```
-Pi-hole DNS (puerto 53) + Pi-hole Web (FTL:80) + MangaCount (Kestrel:3000)
-```
-
-Si **accidentalmente instalaste nginx**: usa `deploy.sh` que incluye validación automática.
-
----
-
-## Deploy Completo (build + publish + copy + restart)
-
-Ejecutar desde la raíz del repositorio en la máquina local:
-
-### 1. Publicar la aplicación
+Run the standard backend deploy from the repository root:
 
 ```bash
-cd /mnt/Files-2tb/repos/MangaCount
-
-dotnet publish MangaCount.Server -c Release -o ./publish
+bash deployment/deploy.sh
 ```
 
-Esto compila el backend y copia el build del frontend (React) como archivos estáticos embebidos.
+The script:
 
-### 2. Copiar al servidor
+- publishes `MangaCount.Server` into `publish/`
+- copies the published output to `/home/pihole/mangacount/app/`
+- installs or refreshes `deployment/mangacount.service`
+- restarts the `mangacount` systemd service
+- validates `http://192.168.0.50:3000/api/profile`
+
+Do not restart the backend with `nohup` or `pkill`. The service unit is the canonical runtime definition.
+
+## WhatsApp bot deploy
+
+Run the bot deploy from the repository root:
 
 ```bash
-scp publish/MangaCount.Server.dll pihole@192.168.0.50:/home/pihole/mangacount/app/
+bash deployment/deploy-bot.sh
 ```
 
-> Si hay otros archivos nuevos en `publish/` (DLLs de dependencias, archivos `wwwroot/`), copiar el directorio completo la primera vez:
-> ```bash
-> scp -r publish/* pihole@192.168.0.50:/home/pihole/mangacount/app/
-> ```
+The script:
 
-### 3. Reiniciar la aplicación
+- syncs the tracked bot runtime into `/home/pihole/mangacount/bot/`
+- preserves the server-side `.env`, `.wwebjs_auth`, `.wwebjs_cache`, and `node_modules/`
+- creates `.env` from `.env.example` on the first deploy if it does not exist yet
+- refreshes `deployment/mangacount-bot.service`
+- installs Chromium if neither `chromium-browser` nor `chromium` is available
+
+If the bot has never authenticated before, the script stops after installing the service file and tells you how to scan the QR code manually.
+
+## Logs
+
+Backend application log:
 
 ```bash
-ssh pihole@192.168.0.50 'bash -s' << 'EOF'
-pkill -f MangaCount.Server.dll || true
-sleep 3
-cd /home/pihole/mangacount/app
-nohup /usr/bin/dotnet MangaCount.Server.dll --urls=http://0.0.0.0:3000 >> manga.log 2>&1 &
-echo "Iniciado con PID $!"
-EOF
+ssh pihole@192.168.0.50 'tail -f /home/pihole/mangacount/logs/backend.txt'
 ```
 
-### 4. Verificar que levantó
+Bot application log:
 
 ```bash
-sleep 3 && curl -s http://192.168.0.50:3000/api/profile
+ssh pihole@192.168.0.50 'tail -f /home/pihole/mangacount/logs/bot.txt'
 ```
 
----
-
-## Deploy Rápido (solo DLL, sin cambios de frontend)
-
-Cuando solo se modificó código C# (sin tocar `mangacount.client`):
+Backend service journal:
 
 ```bash
-# Desde la raíz del repo
-dotnet build MangaCount.Server -c Release
-
-scp MangaCount.Server/bin/Release/net8.0/MangaCount.Server.dll \
-    pihole@192.168.0.50:/home/pihole/mangacount/app/
-
-ssh pihole@192.168.0.50 \
-  'pkill -f MangaCount.Server.dll; sleep 3; cd /home/pihole/mangacount/app && nohup /usr/bin/dotnet MangaCount.Server.dll --urls=http://0.0.0.0:3000 >> manga.log 2>&1 &'
+ssh pihole@192.168.0.50 'journalctl -u mangacount -f --no-pager'
 ```
 
----
-
-## Ver Logs en Tiempo Real
+Bot service journal:
 
 ```bash
-ssh pihole@192.168.0.50 'tail -f /home/pihole/mangacount/app/manga.log'
+ssh pihole@192.168.0.50 'journalctl -u mangacount-bot -f --no-pager'
 ```
 
-Para ver las últimas 50 líneas:
+## Service status
+
+Backend:
 
 ```bash
-ssh pihole@192.168.0.50 'tail -50 /home/pihole/mangacount/app/manga.log'
+ssh pihole@192.168.0.50 'systemctl status mangacount --no-pager'
 ```
 
----
-
-## Verificar Estado del Proceso
+Bot:
 
 ```bash
-ssh pihole@192.168.0.50 'pgrep -a -f MangaCount'
+ssh pihole@192.168.0.50 'systemctl status mangacount-bot --no-pager'
 ```
 
----
+## First bot deploy checklist
 
-## Acceder a la Base de Datos en el Servidor
+1. Run `bash deployment/deploy-bot.sh`.
+2. If the script created `/home/pihole/mangacount/bot/.env`, edit it and set `WHATSAPP_ALLOWED_NUMBERS` before starting the bot.
+3. Connect to the server and run `cd /home/pihole/mangacount/bot && node index.js`.
+4. Scan the QR code with the WhatsApp account assigned to the bot.
+5. Stop the manual process and enable the service with `sudo systemctl enable --now mangacount-bot`.
+
+## Database access
 
 ```bash
 ssh pihole@192.168.0.50 'psql -U pihole -d MangaCount'
 ```
 
-Comandos útiles dentro de psql:
+## Production configuration
 
-```sql
--- Contar registros
-SELECT COUNT(*) FROM manga;
-SELECT COUNT(*) FROM entry;
-SELECT COUNT(*) FROM profile;
-
--- Ver formatos
-SELECT * FROM format;
-
--- Ver editoriales
-SELECT * FROM publisher;
-
--- Salir
-\q
-```
-
----
-
-## Importar Colección desde TSV
-
-Con la app corriendo, enviar el archivo TSV al endpoint de importación para el perfil `1`:
-
-```bash
-curl -X POST http://192.168.0.50:3000/api/entry/import/1 \
-  -H "Content-Type: multipart/form-data" \
-  -F "file=@/mnt/Files-2tb/repos/MangaCount/Inventario - Lucas.tsv"
-```
-
-La respuesta incluye un resumen de los registros importados.
-
----
-
-## Parar la Aplicación
-
-```bash
-ssh pihole@192.168.0.50 'pkill -f MangaCount.Server.dll'
-```
-
----
-
-## Cadena de Conexión en Producción
-
-El archivo `appsettings.Production.json` en el servidor contiene:
-
-```json
-{
-  "ConnectionStrings": {
-    "MangacountDatabase": "Host=localhost;Database=MangaCount;Username=pihole;Password=pihole"
-  }
-}
-```
-
-La variable de entorno `ASPNETCORE_ENVIRONMENT=Production` hace que la app use este archivo en lugar del `appsettings.json` de desarrollo.
+`ASPNETCORE_ENVIRONMENT=Production` is set by `deployment/mangacount.service`, so the backend uses `appsettings.Production.json` on the server.

--- a/deployment/deploy-bot.sh
+++ b/deployment/deploy-bot.sh
@@ -10,6 +10,16 @@ SSH_KEY="$HOME/.ssh/id_mangacount"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BOT_SRC="$REPO_ROOT/WhatsappBot"
 SERVICE_NAME="mangacount-bot"
+BOT_RUNTIME_EXCLUDES=(
+  "--exclude=.env"
+  "--exclude=.gitignore"
+  "--exclude=.wwebjs_auth"
+  "--exclude=.wwebjs_cache"
+  "--exclude=node_modules"
+  "--exclude=*.log"
+  "--exclude=*.test.js"
+  "--exclude=PLAN.md"
+)
 # ─────────────────────────────────────────────────────────────────
 
 SSH_OPTS="-o StrictHostKeyChecking=no"
@@ -21,28 +31,16 @@ ssh_cmd() { ssh $SSH_OPTS "$USER@$SERVER" "$@"; }
 scp_cmd() { scp $SSH_OPTS "$@"; }
 
 echo "==> [1/4] Preparando directorio en servidor..."
-ssh_cmd "mkdir -p $BOT_DIR/src/commands $LOG_DIR"
+ssh_cmd "mkdir -p $BOT_DIR $LOG_DIR"
 
-echo "==> [2/4] Copiando archivos del bot..."
-# Archivos raíz
-scp_cmd "$BOT_SRC/index.js"    "$USER@$SERVER:$BOT_DIR/"
-scp_cmd "$BOT_SRC/package.json" "$USER@$SERVER:$BOT_DIR/"
+echo "==> [2/4] Sincronizando runtime del bot..."
+ssh_cmd "rm -rf $BOT_DIR/src"
+tar "${BOT_RUNTIME_EXCLUDES[@]}" -C "$BOT_SRC" -cf - . | ssh_cmd "tar -xf - -C $BOT_DIR"
 
-# .env: solo copiar si NO existe ya en el servidor (preservar config del server)
 if ! ssh_cmd "test -f $BOT_DIR/.env"; then
-  scp_cmd "$BOT_SRC/.env" "$USER@$SERVER:$BOT_DIR/"
-  echo "    → .env copiado (primera vez)"
+  ssh_cmd "cp $BOT_DIR/.env.example $BOT_DIR/.env"
+  echo "    → .env creado desde .env.example; revisa WHATSAPP_ALLOWED_NUMBERS antes del primer arranque"
 fi
-
-# src/
-scp_cmd "$BOT_SRC/src/api.js"    "$USER@$SERVER:$BOT_DIR/src/"
-scp_cmd "$BOT_SRC/src/authorization.js" "$USER@$SERVER:$BOT_DIR/src/"
-scp_cmd "$BOT_SRC/src/session.js" "$USER@$SERVER:$BOT_DIR/src/"
-scp_cmd "$BOT_SRC/src/router.js"  "$USER@$SERVER:$BOT_DIR/src/"
-scp_cmd "$BOT_SRC/src/commands/buscar.js"     "$USER@$SERVER:$BOT_DIR/src/commands/"
-scp_cmd "$BOT_SRC/src/commands/pendientes.js" "$USER@$SERVER:$BOT_DIR/src/commands/"
-scp_cmd "$BOT_SRC/src/commands/actualizar.js" "$USER@$SERVER:$BOT_DIR/src/commands/"
-scp_cmd "$BOT_SRC/src/commands/recomendar.js" "$USER@$SERVER:$BOT_DIR/src/commands/"
 
 echo "==> [3/4] Instalando dependencias en servidor..."
 # Instalar chromium si falta (necesario para puppeteer/whatsapp-web.js)
@@ -68,6 +66,7 @@ else
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo "  PRIMER DEPLOY: necesitás escanear el QR de WhatsApp"
+  echo "  Si el script creo $BOT_DIR/.env, completa WHATSAPP_ALLOWED_NUMBERS antes de seguir."
   echo ""
   echo "  1. Conectate al servidor:"
   echo "     ssh -i ~/.ssh/id_mangacount pihole@$SERVER"

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -9,6 +9,7 @@ LOG_DIR="$APP_DIR/../logs"
 SSH_KEY="$HOME/.ssh/id_mangacount"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PUBLISH_DIR="$REPO_ROOT/publish"
+SERVICE_NAME="mangacount"
 # ─────────────────────────────────────────────────────────────────
 
 # Si no existe la SSH key, caer en autenticación por contraseña
@@ -50,14 +51,12 @@ for dir in wwwroot recommendations; do
   fi
 done
 
-echo "==> [3/4] Reiniciando aplicación..."
-ssh_cmd "bash -c '
-  pkill -f MangaCount.Server.dll || true
-  sleep 2
-  cd $APP_DIR
-  nohup /usr/bin/dotnet MangaCount.Server.dll --urls=http://0.0.0.0:3000 >> manga.log 2>&1 &
-  echo "PID=\$!"
-'"
+echo "==> [3/4] Actualizando servicio y reiniciando aplicación..."
+scp_cmd "$REPO_ROOT/deployment/mangacount.service" "$USER@$SERVER:/tmp/"
+ssh_cmd "sudo mv /tmp/mangacount.service /etc/systemd/system/"
+ssh_cmd "sudo systemctl daemon-reload"
+ssh_cmd "sudo systemctl enable $SERVICE_NAME >/dev/null 2>&1 || true"
+ssh_cmd "sudo systemctl restart $SERVICE_NAME"
 
 echo "==> [4/4] Validando..."
 sleep 5
@@ -70,6 +69,6 @@ if [ "$STATUS" = "200" ]; then
 else
   echo ""
   echo "✗ La app no respondió (HTTP $STATUS). Revisá los logs:"
-  echo "  ssh $SSH_OPTS $USER@$SERVER 'tail -50 $LOG_DIR/backend.txt || tail -50 $APP_DIR/manga.log'"
+  echo "  ssh $SSH_OPTS $USER@$SERVER 'journalctl -u $SERVICE_NAME -n 50 --no-pager && tail -50 $LOG_DIR/backend.txt'"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- add WhatsApp recommendation access, whitelist enforcement, and daily backend/bot logs from the current develop baseline
- harden deployment by syncing the full bot runtime, bootstrapping missing bot env files from a tracked template, and restarting the backend through systemd
- auto-detect Chromium-compatible browser paths for the bot and document the updated deployment flow
- trigger the Pages workflow when its own workflow file changes

## Verification
- dotnet test MangaCount.Server.Tests --verbosity minimal
- cd mangacount.client && npm test -- --run && npm run build
- cd Pages && npm test -- --run && npm run build
- cd WhatsappBot && npm test
- bash -n deployment/deploy.sh
- bash -n deployment/deploy-bot.sh

## Notes
- this branch is based on the current develop branch state and supersedes the earlier develop-to-main rollout PR
- phone-based WhatsApp validation was not run from this environment